### PR TITLE
Us12 add api reset password and change password

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -13,6 +13,9 @@ security:
             id: fos_user.user_provider.username
 
     firewalls:
+        resetpassword:
+            pattern: ^/api/user/resetting/reset
+            security: false
         refresh:
             pattern: ^/api/token/refresh
             stateless: true
@@ -47,5 +50,6 @@ security:
         - { path: ^/user/login$, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/user/register, role: ROLE_ADMIN }
         - { path: ^/resetting, role: ROLE_ADMIN }
+        - { path: ^/api/user/resetting/reset, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/api/token/refresh, role: IS_AUTHENTICATED_ANONYMOUSLY }
         - { path: ^/api, role: [ROLE_COLLAB, ROLE_ADMIN] }

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -35,3 +35,6 @@ services:
         #arguments: [ @router ]
         tags:
             - { name: kernel.event_subscriber }
+    reset_password_service:
+        alias: fos_user.resetting.form.factory
+        public: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -38,3 +38,6 @@ services:
     reset_password_service:
         alias: fos_user.resetting.form.factory
         public: true
+    change_password_service:
+        alias: fos_user.change_password.form.factory
+        public: true

--- a/src/Controller/ChangePasswordController.php
+++ b/src/Controller/ChangePasswordController.php
@@ -89,7 +89,7 @@ class ChangePasswordController
         /** @var $formFactory \FOS\UserBundle\Form\Factory\FactoryInterface */
         $formFactory = $this->container->get('change_password_service');
         $form = $formFactory->createForm([
-            'csrf_protection'    => false
+            'csrf_protection'    => false,
         ]);
 
         $form->setData($user);

--- a/src/Controller/ChangePasswordController.php
+++ b/src/Controller/ChangePasswordController.php
@@ -1,0 +1,132 @@
+<?php
+namespace App\Controller;
+
+
+use FOS\UserBundle\Event\FilterUserResponseEvent;
+use FOS\UserBundle\Event\FormEvent;
+use FOS\UserBundle\Event\GetResponseUserEvent;
+use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Model\UserInterface;
+use FOS\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration as Configuration;
+
+class ChangePasswordController
+{
+    private $eventDispatcher;
+    private $userManager;
+    private $stokenStorage;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, UserManagerInterface $userManager,
+                                TokenStorageInterface $stokenStorage, ContainerInterface $container)
+    {
+        /** @var eventDispatcher \Symfony\Component\EventDispatcher\EventDispatcherInterface */
+        $this->eventDispatcher = $eventDispatcher;
+        /** @var userManager \FOS\UserBundle\Model\UserManagerInterface */
+        $this->userManager = $userManager;
+        /** @var stokenStorage \Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage */
+        $this->stokenStorage = $stokenStorage;
+        /** @var container \Symfony\Component\DependencyInjection\ContainerInterface */
+        $this->container = $container;
+    }
+
+    /**
+     * Get a user from the Security Token Storage.
+     *
+     * @return mixed
+     *
+     * @throws \LogicException If SecurityBundle is not available
+     *
+     * @see TokenInterface::getUser()
+     */
+    public function getUser()
+    {
+        if (!$this->stokenStorage) {
+            throw new \LogicException('The SecurityBundle is not registered in your application.');
+        }
+
+        if (null === $token = $this->stokenStorage->getToken()) {
+            return;
+        }
+
+        if (!is_object($user = $token->getUser())) {
+            // e.g. anonymous authentication
+            return;
+        }
+
+        return $user;
+    }
+
+    /**
+     * Custom route to do Get operation over User entity with all nested relations
+     * It uses ParamConverter usage to reduce the responsability of the controller
+     *
+     * @Configuration\Route(
+     *     name="user_change_password",
+     *     path="/api/user/changepassword",
+     *     methods={"POST"}
+     * )
+     */
+    public function changePasswordAction(Request $request)
+    {
+        $user = $this->getUser();
+
+        if (!is_object($user) || !$user instanceof UserInterface) {
+            throw new AccessDeniedException('This user does not have access to this section.');
+        }
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        /** @var $formFactory \FOS\UserBundle\Form\Factory\FactoryInterface */
+        $formFactory = $this->container->get('change_password_service');
+        $form = $formFactory->createForm([
+            'csrf_protection'    => false
+        ]);
+
+        $form->setData($user);
+        $form->submit($request->request->all());
+
+        if (!$form->isValid()) {
+            foreach ($form->getErrors(true, true) as $key => $error)
+            {
+                $error = $error->getMessage() . "\n";
+            }
+            return new JsonResponse(
+                // no translation provided for this in \FOS\UserBundle\Controller\ResettingController
+                sprintf('"%s"', $error),
+                JsonResponse::HTTP_BAD_REQUEST
+            );
+        }
+
+        $event = new FormEvent($form, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_SUCCESS, $event);
+
+        $this->userManager->updateUser($user);
+
+        if (null === $response = $event->getResponse()) {
+            return new JsonResponse(
+                $this->container->get('translator')->trans('change_password.flash.success', [], 'FOSUserBundle'),
+                JsonResponse::HTTP_OK
+            );
+        }
+
+        // unsure if this is now needed / will work the same
+        $this->eventDispatcher->dispatch(FOSUserEvents::CHANGE_PASSWORD_COMPLETED, new FilterUserResponseEvent($user,
+            $request,
+            $response));
+
+        return new JsonResponse(
+            $this->container->get('translator')->trans('change_password.flash.success', [], 'FOSUserBundle'),
+            JsonResponse::HTTP_OK
+        );
+    }
+}

--- a/src/Controller/ResettingController.php
+++ b/src/Controller/ResettingController.php
@@ -75,7 +75,15 @@ class ResettingController
         $form->submit($request->request->all());
 
         if (!$form->isValid()) {
-            return $form;
+            foreach ($form->getErrors(true, true) as $key => $error)
+            {
+                $error = $error->getMessage() . "\n";
+            }
+            return new JsonResponse(
+                // no translation provided for this in \FOS\UserBundle\Controller\ResettingController
+                sprintf('"%s"', $error),
+                JsonResponse::HTTP_BAD_REQUEST
+            );
         }
 
         $event = new FormEvent($form, $request);

--- a/src/Controller/ResettingController.php
+++ b/src/Controller/ResettingController.php
@@ -68,7 +68,6 @@ class ResettingController
         $formFactory = $this->container->get('reset_password_service');
         $form = $formFactory->createForm([
             'csrf_protection'    => false,
-            'allow_extra_fields' => true,
         ]);
 
         $form->setData($user);

--- a/src/Controller/ResettingController.php
+++ b/src/Controller/ResettingController.php
@@ -1,0 +1,104 @@
+<?php
+namespace App\Controller;
+
+
+use FOS\UserBundle\Event\FilterUserResponseEvent;
+use FOS\UserBundle\Event\GetResponseUserEvent;
+use FOS\UserBundle\Event\FormEvent;
+use FOS\UserBundle\Form\Factory\FactoryInterface;
+use FOS\UserBundle\FOSUserEvents;
+use FOS\UserBundle\Model\UserManagerInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Request;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration as Configuration;
+
+class ResettingController
+{
+    private $eventDispatcher;
+    private $userManager;
+    private $container;
+
+    public function __construct(EventDispatcherInterface $eventDispatcher, UserManagerInterface $userManager,
+                                ContainerInterface $container)
+    {
+        /** @var eventDispatcher \Symfony\Component\EventDispatcher\EventDispatcherInterface */
+        $this->eventDispatcher = $eventDispatcher;
+        /** @var userManager \FOS\UserBundle\Model\UserManagerInterface */
+        $this->userManager = $userManager;
+        /** @var container \Symfony\Component\DependencyInjection\ContainerInterface */
+        $this->container = $container;
+    }
+
+    /**
+     * Custom route to do Get operation over User entity with all nested relations
+     * It uses ParamConverter usage to reduce the responsability of the controller
+     *
+     * @Configuration\Route(
+     *     name="user_reset_password",
+     *     path="/api/user/resetting/reset/{token}",
+     *     methods={"POST"}
+     * )
+     */
+    public function restPassword(Request $request, $token)
+    {
+        if (null === $token) {
+            return new JsonResponse('You must submit a token.', JsonResponse::HTTP_BAD_REQUEST);
+        }
+
+        $user = $this->userManager->findUserByConfirmationToken($token);
+
+        if (null === $user) {
+            return new JsonResponse(
+                // no translation provided for this in \FOS\UserBundle\Controller\ResettingController
+                sprintf('The user with "confirmation token" does not exist for value "%s"', $token),
+                JsonResponse::HTTP_BAD_REQUEST
+            );
+        }
+
+        $event = new GetResponseUserEvent($user, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_RESET_INITIALIZE, $event);
+
+        if (null !== $event->getResponse()) {
+            return $event->getResponse();
+        }
+
+        /** @var $formFactory \FOS\UserBundle\Form\Factory\FactoryInterface */
+        $formFactory = $this->container->get('reset_password_service');
+        $form = $formFactory->createForm([
+            'csrf_protection'    => false,
+            'allow_extra_fields' => true,
+        ]);
+
+        $form->setData($user);
+        $form->submit($request->request->all());
+
+        if (!$form->isValid()) {
+            return $form;
+        }
+
+        $event = new FormEvent($form, $request);
+        $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_RESET_SUCCESS, $event);
+
+        $this->userManager->updateUser($user);
+
+        if (null === $response = $event->getResponse()) {
+            return new JsonResponse(
+                $this->container->get('translator')->trans('resetting.flash.success', [], 'FOSUserBundle'),
+                JsonResponse::HTTP_OK
+            );
+        }
+
+        // unsure if this is now needed / will work the same
+        $this->eventDispatcher->dispatch(FOSUserEvents::RESETTING_RESET_COMPLETED, new FilterUserResponseEvent($user,
+            $request,
+            $response));
+
+        return new JsonResponse(
+            $this->container->get('translator')->trans('resetting.flash.success', [], 'FOSUserBundle'),
+            JsonResponse::HTTP_OK
+        );
+    }
+
+}

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -34,7 +34,10 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *      "method"="POST",
  *      "access_control"="is_granted('ROLE_ADMIN')",
  *      "access_control_message"="Only admins can create users."
- *    }
+ *    },
+ *    "user_reset_password"={
+ *      "route_name"="user_reset_password"
+ *     }
  *  },
  *  itemOperations={
  *    "get"={

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -37,6 +37,9 @@ use Symfony\Component\Serializer\Annotation\Groups;
  *    },
  *    "user_reset_password"={
  *      "route_name"="user_reset_password"
+ *     },
+ *     "user_change_password"={
+ *      "route_name"="user_change_password"
  *     }
  *  },
  *  itemOperations={

--- a/src/Entity/UserSuggestionLike.php
+++ b/src/Entity/UserSuggestionLike.php
@@ -8,6 +8,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\UserSuggestionLikeRepository")
+ * @ORM\Table(
+ *     uniqueConstraints= {
+ *      @ORM\UniqueConstraint(name="user_suggestion_unique", columns={"user_id", "suggestion_id"})
+ *     }
+ * )
  * @ORM\HasLifecycleCallbacks
  * @ApiResource(
  *  attributes={

--- a/src/Entity/UserSuggestionMegaLike.php
+++ b/src/Entity/UserSuggestionMegaLike.php
@@ -8,6 +8,11 @@ use Symfony\Component\Serializer\Annotation\Groups;
 
 /**
  * @ORM\Entity(repositoryClass="App\Repository\UserSuggestionMegaLikeRepository")
+ * @ORM\Table(
+ *     uniqueConstraints= {
+ *      @ORM\UniqueConstraint(name="user_suggestion_unique", columns={"user_id", "suggestion_id"})
+ *     }
+ * )
  * @ORM\HasLifecycleCallbacks
  * @ApiResource(
  *  attributes={

--- a/src/Migrations/Version20180623211355.php
+++ b/src/Migrations/Version20180623211355.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Migrations\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+class Version20180623211355 extends AbstractMigration
+{
+    public function up(Schema $schema)
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('CREATE UNIQUE INDEX user_suggestion_unique ON user_suggestion_like (user_id, suggestion_id)');
+        $this->addSql('CREATE UNIQUE INDEX user_suggestion_unique ON user_suggestion_mega_like (user_id, suggestion_id)');
+    }
+
+    public function down(Schema $schema)
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('DROP INDEX user_suggestion_unique ON user_suggestion_like');
+        $this->addSql('DROP INDEX user_suggestion_unique ON user_suggestion_mega_like');
+    }
+}


### PR DESCRIPTION
Salut Jean-Gabriel,

A merger sur master.

Deux nouvelles fonctionnalités que j'ai mis en place pour rendre l'application plus safe :
  - la route user_reset_password
  - la route user_change_password

La deux routes utilise les fonctionnalités fosuserBundle, je t'invite à les utiliser. Ci-dessous un exemple pour chaque route :
- la route user_reset_password
curl -X POST \
  http://localhost.apache:81/index.php/api/user/resetting/reset/Test \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/x-www-form-urlencoded' \
  -H 'postman-token: a45470d4-9ea1-ddea-f2a6-afb65774057c' \
  -d 'plainPassword%5Bfirst%5D=admin&plainPassword%5Bsecond%5D=admin'

- la route user_change_password
curl -X POST \
  http://localhost.apache:81/index.php/api/user/changepassword \
  -H 'authorization: Bearer LeBearer' \
  -H 'cache-control: no-cache' \
  -H 'content-type: application/x-www-form-urlencoded' \
  -H 'postman-token: 8c9896c0-156f-e706-97a2-436717f0dc64' \
  -d 'current_password=admin&plainPassword%5Bfirst%5D=admin&plainPassword%5Bsecond%5D=admin'

Zakariae